### PR TITLE
Fix dark mode toggle across site

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,11 +24,11 @@
     // Function to update favicon based on theme
     function updateFavicon() {
       const favicon = document.getElementById("favicon");
-      const isDarkMode = window.matchMedia(
-        "(prefers-color-scheme: dark)"
-      ).matches;
+      const html = document.documentElement;
+      const attrTheme = html.getAttribute("data-theme");
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const isDarkMode = attrTheme ? attrTheme === "dark" : prefersDark;
       favicon.href = isDarkMode ? "/favicon_dark.ico" : "/favicon_light.ico";
-      console.log("Favicon updated to: " + favicon.href);
     }
 
     // Toggle between light and dark themes
@@ -44,6 +44,9 @@
     const savedTheme = localStorage.getItem("theme");
     if (savedTheme) {
       document.documentElement.setAttribute("data-theme", savedTheme);
+    } else {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      document.documentElement.setAttribute("data-theme", prefersDark ? "dark" : "light");
     }
     updateFavicon();
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -23,9 +23,9 @@
     }
 }
 
-.site-nav {
-    float: right;
-    line-height: 56px;
+    .site-nav {
+        float: right;
+        line-height: 56px;
 
     .menu-icon {
         display: none;
@@ -82,6 +82,14 @@
         .page-link {
             display: block;
             padding: 5px 10px;
+        }
+
+        #theme-toggle {
+            background: none;
+            border: none;
+            cursor: pointer;
+            font-size: 20px;
+            margin-left: 10px;
         }
     }
 }

--- a/css/main.scss
+++ b/css/main.scss
@@ -102,3 +102,23 @@ $on-laptop:        800px;
 [data-theme="dark"] .footer-col-wrapper {
   color: lighten($grey-color, 20%);
 }
+
+[data-theme="light"] body {
+  background-color: $background-color;
+  color: $text-color;
+}
+
+[data-theme="light"] a,
+[data-theme="light"] .site-title,
+[data-theme="light"] .page-link {
+  color: $brand-color;
+}
+
+[data-theme="light"] .site-header {
+  border-top-color: $grey-color-dark;
+  border-bottom-color: $grey-color-light;
+}
+
+[data-theme="light"] .footer-col-wrapper {
+  color: $grey-color;
+}


### PR DESCRIPTION
## Summary
- add theme toggle button styles
- support user-selected light theme overriding system preferences
- ensure favicon updates according to selected theme

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687ab97c78c88325bc7cbb3674f3851c