### PR TITLE
Reposition dark mode toggle

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,6 +12,7 @@
           <path fill="#424242" d="M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.031,18,12.696,18,13.516L18,13.516z"/>
         </svg>
       </a>
+      <button id="theme-toggle" aria-label="Toggle dark mode">🌓</button>
 
       <div class="trigger">
         {% for page in site.pages %}
@@ -20,8 +21,6 @@
           {% endif %}
         {% endfor %}
       </div>
-
-      <button id="theme-toggle" aria-label="Toggle dark mode">🌓</button>
     </nav>
 
   </div>


### PR DESCRIPTION
## Summary
- move the dark mode toggle button so it appears before navigation links

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_687abbc3190483259b2e1157538a49c7