### PR TITLE
Fix dark mode button overlap

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,6 +2,7 @@
 
   <div class="wrapper">
 
+    <button id="theme-toggle" aria-label="Toggle dark mode">🌓</button>
     <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a>
 
     <nav class="site-nav">
@@ -12,7 +13,6 @@
           <path fill="#424242" d="M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.031,18,12.696,18,13.516L18,13.516z"/>
         </svg>
       </a>
-      <button id="theme-toggle" aria-label="Toggle dark mode">🌓</button>
 
       <div class="trigger">
         {% for page in site.pages %}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -10,6 +10,16 @@
     position: relative;
 }
 
+#theme-toggle {
+    float: left;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+    line-height: 56px;
+    margin-right: 10px;
+}
+
 .site-title {
     font-size: 26px;
     line-height: 56px;
@@ -84,13 +94,6 @@
             padding: 5px 10px;
         }
 
-        #theme-toggle {
-            background: none;
-            border: none;
-            cursor: pointer;
-            font-size: 20px;
-            margin-left: 10px;
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- move dark mode toggle before the site title in the header
- float and style the toggle so it doesn't cover page headings

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687ac527d16083259ed9edc16fe2197e